### PR TITLE
fix: Terminal widgets don't support Ctrl+V paste (#8)

### DIFF
--- a/src/renderer/src/components/DevServerPeek.tsx
+++ b/src/renderer/src/components/DevServerPeek.tsx
@@ -5,6 +5,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { useActiveProject } from '../stores/workspace-store'
 import { useDevServerStore } from '../stores/devserver-store'
+import { attachClipboardHandler } from '../lib/terminal-clipboard'
 import { DEV_SERVER_SUFFIX } from '../../../shared/types'
 
 export function DevServerPeek(): React.JSX.Element | null {
@@ -94,21 +95,7 @@ function DevServerPeekPanel({ projectId, rootPath, devCommand, onClose, onRunnin
 
     terminal.open(containerRef.current)
 
-    // Ctrl+V paste / Ctrl+C copy-selection — Electron doesn't wire native
-    // clipboard events for xterm.js, so we handle them manually.
-    terminal.attachCustomKeyEventHandler((event) => {
-      if (event.type === 'keydown' && event.ctrlKey && event.key === 'v') {
-        navigator.clipboard.readText().then((text) => {
-          if (text) terminal.paste(text)
-        })
-        return false
-      }
-      if (event.type === 'keydown' && event.ctrlKey && event.key === 'c' && terminal.hasSelection()) {
-        navigator.clipboard.writeText(terminal.getSelection())
-        return false
-      }
-      return true
-    })
+    attachClipboardHandler(terminal)
 
     try {
       terminal.loadAddon(new WebglAddon())

--- a/src/renderer/src/lib/terminal-clipboard.ts
+++ b/src/renderer/src/lib/terminal-clipboard.ts
@@ -1,0 +1,25 @@
+import type { Terminal } from '@xterm/xterm'
+
+/**
+ * Attach Ctrl+V paste and Ctrl+C copy-selection to an xterm.js terminal.
+ * Electron's frameless window doesn't wire native clipboard events for
+ * xterm.js, so we handle them manually.
+ */
+export function attachClipboardHandler(terminal: Terminal): void {
+  terminal.attachCustomKeyEventHandler((event) => {
+    if (event.type === 'keydown' && event.ctrlKey && event.key === 'v') {
+      navigator.clipboard
+        .readText()
+        .then((text) => {
+          if (text) terminal.paste(text)
+        })
+        .catch(() => {})
+      return false
+    }
+    if (event.type === 'keydown' && event.ctrlKey && event.key === 'c' && terminal.hasSelection()) {
+      navigator.clipboard.writeText(terminal.getSelection()).catch(() => {})
+      return false
+    }
+    return true
+  })
+}

--- a/src/renderer/src/widgets/TerminalWidget.tsx
+++ b/src/renderer/src/widgets/TerminalWidget.tsx
@@ -4,6 +4,7 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebglAddon } from '@xterm/addon-webgl'
 import { useActiveProject, useWorkspaceStore } from '../stores/workspace-store'
 import { getInstanceSuffix } from '../stores/widget-registry'
+import { attachClipboardHandler } from '../lib/terminal-clipboard'
 import type { ITheme } from '@xterm/xterm'
 
 const defaultTheme: ITheme = {
@@ -105,21 +106,7 @@ export function TerminalWidget({ instanceId }: TerminalWidgetProps): React.JSX.E
 
     terminal.open(containerRef.current)
 
-    // Ctrl+V paste / Ctrl+C copy-selection — Electron doesn't wire native
-    // clipboard events for xterm.js, so we handle them manually.
-    terminal.attachCustomKeyEventHandler((event) => {
-      if (event.type === 'keydown' && event.ctrlKey && event.key === 'v') {
-        navigator.clipboard.readText().then((text) => {
-          if (text) terminal.paste(text)
-        })
-        return false
-      }
-      if (event.type === 'keydown' && event.ctrlKey && event.key === 'c' && terminal.hasSelection()) {
-        navigator.clipboard.writeText(terminal.getSelection())
-        return false
-      }
-      return true
-    })
+    attachClipboardHandler(terminal)
 
     // Try loading WebGL addon for GPU-accelerated rendering
     try {


### PR DESCRIPTION
Closes #8